### PR TITLE
#157731629 Enable social login

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,11 +20,11 @@ django-bower
 invoke
 requests
 psycopg2-binary
-coverage
 whitenoise
 gunicorn
 dj-database-url==0.4.2
 dj-static==0.0.6
+social-auth-app-django
 
 # REST API
 djangorestframework>=3.2,<3.3
@@ -36,4 +36,3 @@ django-cors-headers
 six
 autopep8
 flake8
-psycopg2-binary

--- a/settings.py
+++ b/settings.py
@@ -16,11 +16,11 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('WG_NAME') or "test_wger",
+        'NAME': os.environ.get('WG_NAME') or 'test_wger',
         'USER': os.environ.get('WG_USER') or 'postgres',
         'HOST': os.environ.get('WG_HOST') or 'localhost',
         'PASSWORD': os.environ.get('WG_PASSWORD') or '',
-        'PORT': os.environ.get('WG_PORT') or '',
+        'PORT': os.environ.get('WG_PORT') or '5432',
     }
 }
 
@@ -46,7 +46,7 @@ MEDIA_URL = '/media/'
 ALLOWED_HOSTS = '*'
 
 # This might be a good idea if you setup memcached
-# SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+#SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 # Configure a real backend in production
 if DEBUG:
@@ -56,4 +56,10 @@ if DEBUG:
 WGER_SETTINGS['EMAIL_FROM'] = 'wger Workout Manager <wger@example.com>'
 
 # Your twitter handle, if you have one for this instance.
-# WGER_SETTINGS['TWITTER'] = ''
+#WGER_SETTINGS['TWITTER'] = ''
+
+try:
+    from local_settings import *
+except ImportError:
+    pass
+    

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,12 @@
 universal = 1
 
 [pep8]
-exclude = urls.py,tasks.py,*migrations*,*bower_components*
+exclude = urls.py,tasks.py,*migrations*,*bower_components*,*env*,
 max-line-length = 100
 ignore = W503
 
 # Flake8 configuration settings
 [flake8]
-exclude = .git,__pycache__,urls.py,tasks.py,generator.py,*migrations*,*bower_components*,*docs*,__*__,
+exclude = .git,__pycache__,urls.py,tasks.py,generator.py,*migrations*,*bower_components*,*docs*,*env*,__*__,
 max-line-length = 100
 ignore = F401,W503

--- a/wger/core/templates/user/login.html
+++ b/wger/core/templates/user/login.html
@@ -14,6 +14,11 @@
     {% trans 'Login' as submit_text %}
     {% render_form_fields form submit_text %}
 </form>
+<hr/>
+<h3 class="text text-primary text-center">Login/Register with social apps</h3>
+<div class="row text-center">
+    <a href="{% url 'social:begin' 'facebook' %}"><i class="fa fa-4x fa-facebook"></i></a>&nbsp;&nbsp;<a href="{% url 'social:begin' 'twitter' %}"><i class="fa fa-4x fa-twitter text-info"></i></a>&nbsp;&nbsp;<a href="{% url 'social:begin' 'google-oauth2' %}"><i class="fa fa-4x fa-google text-danger"></i></a>
+</div>
 {% endblock %}
 
 

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -91,3 +91,4 @@ class MuscleSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = Muscle
+        

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 
 # This file is part of wger Workout Manager.
@@ -90,7 +91,6 @@ class ExercisesViewSet(viewsets.ReadOnlyModelViewSet):
 def search(request):
     '''
     Searches for exercises.
-
     This format is currently used by the exercise search autocompleter
     '''
     q = request.GET.get('term', None)
@@ -216,3 +216,4 @@ class MuscleViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = '__all__'
     filter_fields = ('name',
                      'is_front')
+                     

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -1,3 +1,4 @@
+
 # This file is part of wger Workout Manager.
 #
 # wger Workout Manager is free software: you can redistribute it and/or modify
@@ -552,3 +553,4 @@ class ExerciseApiTest(WorkoutManagerTestCase):
         response = client.post('/api/v2/exercises/', data=data)
         # Test for method not allowed
         self.assertEqual(response.status_code, 405)
+        

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -31,12 +31,24 @@ import os
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
 
+
 #
 # Application definition
 #
 SITE_ID = 1
 ROOT_URLCONF = 'wger.urls'
 WSGI_APPLICATION = 'wger.wsgi.application'
+
+# twitter keys
+SOCIAL_AUTH_TWITTER_KEY = os.environ.get('SOCIAL_AUTH_TWITTER_KEY')
+SOCIAL_AUTH_TWITTER_SECRET = os.environ.get('SOCIAL_AUTH_TWITTER_SECRET')
+SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/'
+# facebook keys
+SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('SOCIAL_AUTH_FACEBOOK_KEY')
+SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET')
+# google keys
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH_KEY')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH_SECRET')
 
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -89,6 +101,9 @@ INSTALLED_APPS = (
 
     # django-bower for installing bower packages
     'djangobower',
+
+    # social login
+    'social_django',
 )
 
 # added list of external libraries to be installed by bower
@@ -126,6 +141,10 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.locale.LocaleMiddleware',
 
+
+    # social login
+    'social_django.middleware.SocialAuthExceptionMiddleware',
+
     # Django mobile
     'django_mobile.middleware.MobileDetectionMiddleware',
     'django_mobile.middleware.SetFlavourMiddleware',
@@ -133,7 +152,11 @@ MIDDLEWARE_CLASSES = (
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
-    'wger.utils.helpers.EmailAuthBackend'
+    'wger.utils.helpers.EmailAuthBackend',
+    # social login
+    'social_core.backends.twitter.TwitterOAuth',
+    'social_core.backends.facebook.FacebookOAuth2',
+    'social_core.backends.google.GoogleOAuth2',
 )
 
 TEMPLATES = [
@@ -157,7 +180,11 @@ TEMPLATES = [
                 'django_mobile.context_processors.flavour',
 
                 # Breadcrumbs
-                'django.template.context_processors.request'
+                'django.template.context_processors.request',
+
+                # social login
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
             'loaders': [
                 # Django mobile
@@ -385,3 +412,4 @@ STATICFILES_DIRS = (
 
 if 'DATABASE_URL' in os.environ:
     DATABASES = {'default': dj_database_url.config()}
+    

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -145,6 +145,7 @@ urlpatterns = i18n_patterns(
     url(r'config/', include('wger.config.urls', namespace='config', app_name='config')),
     url(r'gym/', include('wger.gym.urls', namespace='gym', app_name='gym')),
     url(r'email/', include('wger.email.urls', namespace='email')),
+    url(r'^oauth/', include('social_django.urls', namespace='social')),
     url(r'^sitemap\.xml$',
         sitemap,
         {'sitemaps': sitemaps},
@@ -177,3 +178,4 @@ urlpatterns += [
 #
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    


### PR DESCRIPTION
### What does this PR do?
Enables a user to use social login using twitter, facebook and google
#### Description of Task to be completed?
Previously, wger only limited the users to use a login form in order to get access to the application but this method can be hectic especially if you are a new user who may need to register as well.

This PR eases the login process by providing the users with the ability to sign in using twitter, facebook and google.

#### Screenshots
<img width="500" alt="icons" src="https://user-images.githubusercontent.com/17830204/41018073-b9e2a28a-6960-11e8-8c77-96df02ff6310.png">
Login page with social media icons
<img width="500" alt="login" src="https://user-images.githubusercontent.com/17830204/41018088-d1a2d746-6960-11e8-94e7-e4fc1ad72351.png">
Authentication by the social media authoriser
<img width="500" alt="success" src="https://user-images.githubusercontent.com/17830204/41018109-e7d7352a-6960-11e8-972d-6becd84626f2.png">
Successful access to wger after social login accepted

#### How should this be manually tested?
1. Follow the readme.rst procedures on how to set up the application locally
2. Run the migrations
    python manage.py migrate
3. Set the following environment variables

    SOCIAL_AUTH_TWITTER_KEY
    SOCIAL_AUTH_TWITTER_SECRET

    SOCIAL_AUTH_FACEBOOK_KEY
    SOCIAL_AUTH_FACEBOOK_SECRET

   SOCIAL_AUTH_GOOGLE_OAUTH_KEY
   SOCIAL_AUTH_GOOGLE_OAUTH_SECRET

4. Navigate to the login section
5. Select either the twitter, facebook or google icons
6. Follow the prompts provided the social application provider login
7. To logout, use the default logout link
#157731629