### PR TITLE
#157731615 Exercise cache when deleting muscles

### DIFF
--- a/wger/exercises/templates/exercise/view.html
+++ b/wger/exercises/templates/exercise/view.html
@@ -308,6 +308,27 @@ $(document).ready(function() {
         </div>
     </div>
 </div>
+{% else %}
+<div class="row" style="margin-top:1em;">
+    <div class="col-xs-3">
+        <strong>{% trans "Muscles" %}:</strong>
+    </div>
+    <div class="col-xs-9">
+        <p>
+            {% trans "There are no muscles associated this exercise" %}
+        </p>
+        <div>
+            <div style="width:1em;height:1em;background-color:#cc0000;float:left;margin-right:0.5em;"></div>
+            {% trans "Main muscles" %}
+        </div>
+
+        <div>
+            <div style="width:1em;height:1em;background-color:#f57900;float:left;margin-right:0.5em;"></div>
+            {% trans "Secondary muscles" %}
+        </div>
+    </div>
+</div>
+
 {% endif %}
 {% endwith %}
 {% endwith %} {# end musclelist #}

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -27,12 +27,13 @@ from django.views.generic import (
     UpdateView
 )
 
-from wger.exercises.models import Muscle
+from wger.exercises.models import Muscle, Exercise
 from wger.utils.generic_views import (
     WgerFormMixin,
     WgerDeleteMixin
 )
 from wger.utils.language import load_item_languages
+from wger.utils.cache import cache
 from wger.config.models import LanguageConfig
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### What does this PR do?
Refreshes the descriptions cache whenever someone deletes a muscle or updates an exercise.
#### Description of Task to be completed?
1. Run Autopep8 on the code base
#### How should this be manually tested?
1. Run the commands below
```
$ git clone https://github.com/andela/wg-rogue-one.git

$ git checkout ft-exercise-cache-157731615

```
follow the setup instructions in [README.rst](https://github.com/andela/wg-rogue-one/blob/ch-heroku-deployment-157842572/README.rst)
2. Run the app with `python manage.py runserver`
3. Login to wger 
4. Navigate to the `Muscles overview` and add a new muscle. 
5.  Navigate to the `Exercises overview` and add the new muscle on an exercise. 
6. Delete the muscle.
7.  Navigate to the exercise and check to see that the deleted muscle has been removed from the exercise 


#### Any background context you want to provide?
It seems that after deleting a muscle, it keeps appearing in descriptions etc. This is probably due to the cache not being correctly reset.
The cache should be reset after a muscle has been deleted

I have added a template clearing functionality in the muscles.py, exercise.py and add cache.py such that everytime someone deletes a muscle and each time someone edits an exercise the description is
updated.
#### What are the relevant pivotal tracker stories?
#157731615

