### PR TITLE
Enable Cache nutritional values for plan  

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -91,4 +91,3 @@ class MuscleSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = Muscle
-        

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -216,4 +216,3 @@ class MuscleViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = '__all__'
     filter_fields = ('name',
                      'is_front')
-                     

--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -25,6 +25,7 @@ from easy_thumbnails.signals import saved_file
 from wger.exercises.models import ExerciseImage, Muscle, Exercise
 from wger.utils.cache import delete_template_fragment_cache, get_template_cache_name, cache
 
+
 @receiver(pre_delete, sender=Muscle)
 def delete_exercise_template_on_delete(sender, instance, **kwargs):
     '''
@@ -33,11 +34,12 @@ def delete_exercise_template_on_delete(sender, instance, **kwargs):
 
     delete_template_fragment_cache('muscle-overview')
     exercises_to_update = Exercise.objects.filter(muscles=instance)
-    if len(exercises_to_update) >0:
+    if len(exercises_to_update) > 0:
         for exc in exercises_to_update:
 
             delete_template_fragment_cache('exercise-detail-muscles', exc.id, exc.language.id)
             delete_template_fragment_cache('exercise-overview', exc.language.id)
+
 
 @receiver(post_delete, sender=ExerciseImage)
 def delete_exercise_image_on_delete(sender, instance, **kwargs):

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -553,4 +553,3 @@ class ExerciseApiTest(WorkoutManagerTestCase):
         response = client.post('/api/v2/exercises/', data=data)
         # Test for method not allowed
         self.assertEqual(response.status_code, 405)
-        

--- a/wger/nutrition/apps.py
+++ b/wger/nutrition/apps.py
@@ -13,11 +13,13 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
+
+from django.apps import AppConfig
 
 
-from wger import get_version
+class NutritionPlanConfig(AppConfig):
+    name = 'wger.nutrition'
+    verbose_name = "Nutrition"
 
-VERSION = get_version()
-
-default_app_config = 'wger.nutrition.apps.NutritionPlanConfig'
+    def ready(self):
+        import wger.nutrition.signals

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -109,50 +109,57 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
+        nutritional_values_canonical_form = cache.get(
+            cache_mapper.get_nutritional_values_canonical(self.pk))
+        if not nutritional_values_canonical_form:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                      'percent': {'protein': 0,
+                                  'carbohydrates': 0,
+                                  'fat': 0},
+                      'per_kg': {'protein': 0,
+                                 'carbohydrates': 0,
+                                 'fat': 0},
+                      }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
 
-        return result
+            nutritional_values_canonical_form = result
+
+            cache.set(cache_mapper.get_nutritional_values_canonical(self.pk),
+                      nutritional_values_canonical_form)
+        return nutritional_values_canonical_form
 
     def get_closest_weight_entry(self):
         '''

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import reset_nutritional_values_canonical_form
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_delete, sender=Meal)
+@receiver(post_delete, sender=MealItem)
+def delete_cache(sender, **kwargs):
+    """ Function for intercepting signals """
+
+    sender_instance = kwargs['instance']
+    if sender == NutritionPlan:
+        pk = sender_instance.pk
+    elif sender == Meal:
+        pk = sender_instance.plan.pk
+    elif sender == MealItem:
+        pk = sender_instance.meal.plan.pk
+
+    reset_nutritional_values_canonical_form(pk)

--- a/wger/nutrition/templates/plan/overview.html
+++ b/wger/nutrition/templates/plan/overview.html
@@ -7,6 +7,7 @@
 
 {% block content %}
 <div class="list-group">
+
     {% for plan in plans %}
         <a href="{{ plan.get_absolute_url }}" class="list-group-item">
             <span class="glyphicon glyphicon-chevron-right pull-right"></span>

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -23,7 +23,7 @@ from wger.core.tests.base_testcase import (
     WorkoutManagerEditTestCase,
     WorkoutManagerAddTestCase
 )
-from wger.nutrition.models import Meal,MealItem
+from wger.nutrition.models import Meal, MealItem
 from wger.nutrition.models import NutritionPlan
 
 
@@ -61,13 +61,14 @@ class AddMealTestCase(WorkoutManagerAddTestCase):
     user_success = 'test'
     user_fail = 'admin'
 
+
 class AddMealItemTestCase(WorkoutManagerAddTestCase):
     '''
     Tests adding a Meal with meal items
     '''
     object_class = MealItem
     url = reverse('nutrition:meal_item:add_meal', kwargs={'plan_pk': 4})
-    data = {'time': datetime.time(9, 2),'ingredient': 1,'amount': 1}
+    data = {'time': datetime.time(9, 2), 'ingredient': 1, 'amount': 1}
     user_success = 'test'
     user_fail = 'test1'
 

--- a/wger/nutrition/tests/test_nutritional_values_canonical.py
+++ b/wger/nutrition/tests/test_nutritional_values_canonical.py
@@ -1,0 +1,59 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+
+import datetime
+from django.core.cache import cache
+from wger.utils.cache import cache_mapper
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.nutrition.models import NutritionPlan
+
+
+class NutritionInfoCacheTestCase(WorkoutManagerTestCase):
+    '''
+    Test case for the nutritional values caching
+    '''
+
+    def test_meal_nutritional_values_cache(self):
+        '''
+        Tests that the nutrition cache of the canonical form is
+        correctly generated
+        '''
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_values_canonical(1)))
+
+        plan = NutritionPlan.objects.get(pk=1)
+        plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_values_canonical(1)))
+
+    def test_nutritional_values_cache_save(self):
+        '''
+        Tests nutritional values cache when saving
+        '''
+        plan = NutritionPlan.objects.get(pk=1)
+        plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_values_canonical(1)))
+
+        plan.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_values_canonical(1)))
+
+    def test_nutritional_values_cache_delete(self):
+        '''
+        Tests the nutritional values cache when deleting
+        '''
+        plan = NutritionPlan.objects.get(pk=1)
+        plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_values_canonical(1)))
+
+        plan.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_values_canonical(1)))

--- a/wger/nutrition/views/meal_item.py
+++ b/wger/nutrition/views/meal_item.py
@@ -73,7 +73,6 @@ class MealItemCreateView(WgerFormMixin, CreateView):
             else:
                 return HttpResponseForbidden()
         return super(MealItemCreateView, self).dispatch(request, *args, **kwargs)
-        
 
     def get_success_url(self):
         return reverse('nutrition:plan:view', kwargs={'id': self.meal.plan.id})
@@ -85,11 +84,11 @@ class MealItemCreateView(WgerFormMixin, CreateView):
         context = super(MealItemCreateView, self).get_context_data(**kwargs)
         if self.meal_id:
             context['form_action'] = reverse('nutrition:meal_item:add',
-                                         kwargs={'meal_id': self.meal.id})
+                                             kwargs={'meal_id': self.meal.id})
         else:
-            #create meal based on the nutrition plan id
+            # create meal based on the nutrition plan id
             context['form_action'] = reverse('nutrition:meal_item:add_meal',
-                                         kwargs={'plan_pk': self.kwargs['plan_pk']})
+                                             kwargs={'plan_pk': self.kwargs['plan_pk']})
         context['ingredient_searchfield'] = self.request.POST.get('ingredient_searchfield', '')
         context['plan_pk'] = self.plan_pk
         return context
@@ -97,14 +96,14 @@ class MealItemCreateView(WgerFormMixin, CreateView):
     def form_valid(self, form):
         '''
         Manually set the corresponding meal
-        '''  
+        '''
         if not self.meal_id:
             plan = get_object_or_404(NutritionPlan, pk=self.kwargs['plan_pk'])
             meal = Meal.objects.create(plan=plan, order=1)
             meal.time = form.cleaned_data['time']
             meal.save()
             self.meal = meal
-        
+
         form.instance.meal = self.meal
         form.instance.order = 1
         return super(MealItemCreateView, self).form_valid(form)

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -412,4 +412,3 @@ STATICFILES_DIRS = (
 
 if 'DATABASE_URL' in os.environ:
     DATABASES = {'default': dj_database_url.config()}
-    

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -43,6 +43,10 @@ def reset_workout_canonical_form(workout_id):
     cache.delete(cache_mapper.get_workout_canonical(workout_id))
 
 
+def reset_nutritional_values_canonical_form(value_id):
+    cache.delete(cache_mapper.get_nutritional_values_canonical(value_id))
+
+
 def reset_workout_log(user_pk, year, month, day=None):
     '''
     Resets the cached workout logs
@@ -67,6 +71,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITIONAL_VALUES_CANONICAL_REPRESENTATION = 'nutritional-canonical-representation-{0}'
 
     def get_pk(self, param):
         '''
@@ -114,6 +119,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutritional_values_canonical(self, param):
+        '''
+        Return the nutritional values canonical representation
+        '''
+        return self.NUTRITIONAL_VALUES_CANONICAL_REPRESENTATION.format(self.get_pk(param))
 
 
 cache_mapper = CacheKeyMapper()

--- a/wger/utils/helpers.py
+++ b/wger/utils/helpers.py
@@ -192,6 +192,7 @@ def check_access(request_user, username=None):
     is_owner = request_user == user
     return is_owner, user
 
+
 def compare_access(request_user, gymId=None, username=None):
     '''
     Small helper function to check that the current (possibly unauthenticated)
@@ -216,6 +217,7 @@ def compare_access(request_user, gymId=None, username=None):
             return user
         else:
             raise Http404('You are not allowed to access this page.')
+
 
 def normalize_decimal(d):
     '''

--- a/wger/utils/tests/test_check_access.py
+++ b/wger/utils/tests/test_check_access.py
@@ -54,6 +54,7 @@ class CheckAccessTestCase(WorkoutManagerTestCase):
         self.assertEqual(check_access(user_no_share), (True, user_no_share))
         self.assertRaises(Http404, check_access, user_no_share, 'not_a_username')
 
+
 class CompareAccessTestCase(WorkoutManagerTestCase):
     '''
     Test the "compare_access" helper function
@@ -67,6 +68,4 @@ class CompareAccessTestCase(WorkoutManagerTestCase):
         user_share = User.objects.get(pk=1)
         test_user = User.objects.filter(username='test')[0]
 
-        anon = AnonymousUser()
-
-        self.assertEqual(compare_access(user_share.username, 1 , 'test'), test_user)
+        self.assertEqual(compare_access(user_share.username, 1, 'test'), test_user)

--- a/wger/weight/views.py
+++ b/wger/weight/views.py
@@ -186,6 +186,7 @@ def get_weight_data(request, username=None):
     # Return the results to the client
     return Response(chart_data)
 
+
 @api_view(['GET'])
 def compare_weight_data(request, gym=None, username=None):
     '''


### PR DESCRIPTION
### What does this PR do?
When a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. This PR solves that by implementing cache so as to increase perfomance and load time by caching the data.

#### Description of Task to be completed?
- Cache the nutritional_info dictionary in NutritionPlans
- Add signals that delete the cache key everytime a NutritionPlan, Meal and MealItem is added, edited or deleted.

### How should this be manually tested?

1. Follow the setup instructions in [README.rst](https://github.com/andela/wg-rogue-one/blob/ft-cache-nutritional-plan-157731610/README.rst)
2. Run the ```python manage.py test wger.nutrition.tests.test_nutritional_values_canonical```  command. The test ensures that the cache is working.

### Any background context you want to provide?
Before implementing cache, the nutrition plans was not cached so If a user has many plans,
the overview rendered slowly as too many DB-queries are fired just to
calculate the total calories. Some caching of the values has sped up rendering of the overview.

### What are the relevant pivotal tracker stories?
[#157731610](https://www.pivotaltracker.com/story/show/157731610)

