### PR TITLE
#157731616 Make translations of exercises and ingredients easier

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,7 +8,39 @@
 <!--
         Title
 -->
-{% block title %}{% trans "Exercises" %}{% endblock %}
+
+{% block title %}{% trans "Exercises" %}
+<span style="margin-left: 260px; font-size: 20px">View exercises by language:</span>
+<div class="btn-group" style="float:right; display: inline-block;">
+    <button id="filter-lang" type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown" style="padding: 5px">
+        {% if active_lang %}
+        {{active_lang.full_name}}
+        {% else %}
+        Select
+        {% endif %}
+    <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href={% url 'exercise:exercise:overview' %}></a></li>
+        {% for short_name, full_name in languages %}
+        <li style="margin-left: 15px;">
+            <img src="/static/images/icons/flag-{{ short_name }}.svg"
+                width="18"
+                height="11"
+                alt="{% trans full_name %}"
+                title="{% trans full_name %}"
+                style="border: 1px solid #151515;">
+            <span>
+                <a href="{% url 'exercise:exercise:overview' %}?lang={{ short_name }}">
+                    {% trans full_name %}
+                </a>
+            </span>
+            <li class="divider"></li>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}
 
 
 
@@ -38,7 +70,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 
 <ul class="nav nav-tabs">

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -514,6 +514,18 @@ class WorkoutCacheTestCase(WorkoutManagerTestCase):
         for workout_id in workout_ids:
             self.assertFalse(cache.get(cache_mapper.get_workout_canonical(workout_id)))
 
+    def test_exercise_language_filter_works(self):
+        """
+        Test exercise filter language works
+        """
+        self.user_login()
+        response = self.client.get(
+            reverse('exercise:exercise:overview'), {'active_lang': 'en'})
+        self.assertEqual(5, len(response.context['exercises']))
+        response = self.client.get(
+            reverse('exercise:exercise:overview'), {'active_lang': 'de'})
+        self.assertEqual(5, len(response.context['exercises']))
+
 
 class ExerciseApiTest(WorkoutManagerTestCase):
     def test_exercise_read_only_endpoint(self):

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -26,7 +26,39 @@
     </script>
 {% endblock %}
 
-{% block title %}{% trans "Ingredient overview" %}{% endblock %}
+{% block title %}{% trans "Ingredient overview" %}
+<span style="margin-left: 100px; font-size: 20px">View ingredients by language:</span>
+<div class="btn-group" style="float:right;">
+    <button id="filter-lang" type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown" style="padding: 5px">
+        {% if active_lang %}
+        {{active_lang.full_name}}
+        {% else %}
+        Select
+        {% endif %}
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href={% url 'nutrition:ingredient:list' %}></a></li>
+        {% for short_name, full_name in languages %}
+        <li style="margin-left: 15px;">
+            <img src="/static/images/icons/flag-{{ short_name }}.svg"
+                width="18"
+                height="11"
+                alt="{% trans full_name %}"
+                title="{% trans full_name %}"
+                style="border: 1px solid #151515;"
+                >
+    
+            <span>
+                <a href="{% url 'nutrition:ingredient:list' %}?lang={{ short_name }}">
+                    {% trans full_name %}
+                </a>
+            </span>
+            <li class="divider"></li>  
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}
 
 
 {% block content %}


### PR DESCRIPTION
### What does this PR do?
This PR Makes translations of exercises and ingredients easier 

#### Description of Task to be completed?
The user should be able to select which languages to show. They should not be shown only their current language.

### How should this be manually tested?

1. Follow the setup instructions in [README.rst](https://github.com/andela/wg-rogue-one/blob/ft-translate-exercises-and-ingredients-157731616/README.rst)
2. Log in as an admin(Use default Username: admin, Password: admin)
3. From the dashboard, click on the exercise tab, select exercise overview link from the drop-down menu.
4. From the overview page, you show be able to see a select language option button, choose the language to view the list of exercises added for that particular language. 
5. Repeat the above steps for ingredients but using the ingredients overview link under the nutrition tab.

### Screen Shots

Exercise overview Page 

<img width="1279" alt="exercises" src="https://user-images.githubusercontent.com/12033494/41914696-94971220-795c-11e8-8a25-2f1fc2fc605a.png">


Ingredient overview Page 

<img width="1280" alt="nutrition" src="https://user-images.githubusercontent.com/12033494/41914709-9ff87bcc-795c-11e8-9178-15bbded30482.png">




### Any background context you want to provide?
This feature was not available.

### What are the relevant pivotal tracker stories?
[#157731616](https://www.pivotaltracker.com/story/show/157731616)